### PR TITLE
feat: add sendPaddlePurchase

### DIFF
--- a/sdk/src/__tests__/internal/QonversionInternal.test.ts
+++ b/sdk/src/__tests__/internal/QonversionInternal.test.ts
@@ -5,6 +5,7 @@ import Qonversion, {
   Entitlement,
   Environment,
   LogLevel,
+  PaddleStoreData,
   PurchaseCoreData,
   StripeStoreData,
   UserPropertyKey,
@@ -285,5 +286,43 @@ describe('PurchasesController usage tests', () => {
       expect(res).toStrictEqual(promiseReturned);
       expect(purchasesController.sendStripePurchase).toBeCalledWith(requestData);
       expect(logger.verbose).toBeCalledWith('sendStripePurchase() call');
+    });
+
+  test('sendPaddlePurchase',
+    () => {
+      // given
+      const responseData: UserPurchase = {
+        currency: 'USD',
+        price: '9.99',
+        purchased: 1716300000,
+        paddleStoreData: {
+          transactionId: 'txn_01hv4rrk',
+          customerId: 'ctm_01hv4rrk',
+          productId: 'pro_01hv4rrk',
+          subscriptionId: 'sub_01hv4rrk',
+          type: 'subscription',
+        },
+        userId: 'Qon_test_user_id'
+      };
+      const requestData: PurchaseCoreData & PaddleStoreData = {
+        currency: 'USD',
+        price: '9.99',
+        purchased: 1716300000,
+        transactionId: 'txn_01hv4rrk',
+        customerId: 'ctm_01hv4rrk',
+        productId: 'pro_01hv4rrk',
+        subscriptionId: 'sub_01hv4rrk',
+        type: 'subscription',
+      };
+      const promiseReturned = new Promise<UserPurchase>(() => responseData);
+      purchasesController.sendPaddlePurchase = jest.fn(async () => promiseReturned);
+
+      // when
+      const res = qonversionInternal.sendPaddlePurchase(requestData);
+
+      // then
+      expect(res).toStrictEqual(promiseReturned);
+      expect(purchasesController.sendPaddlePurchase).toBeCalledWith(requestData);
+      expect(logger.verbose).toBeCalledWith('sendPaddlePurchase() call');
     });
 });

--- a/sdk/src/__tests__/internal/QonversionInternal.test.ts
+++ b/sdk/src/__tests__/internal/QonversionInternal.test.ts
@@ -8,8 +8,9 @@ import Qonversion, {
   PaddleStoreData,
   PurchaseCoreData,
   StripeStoreData,
+  UserPaddlePurchase,
   UserPropertyKey,
-  UserPurchase,
+  UserStripePurchase,
 } from '../../index';
 import {UserPropertiesController} from '../../internal/userProperties';
 import {UserController} from '../../internal/user';
@@ -259,7 +260,7 @@ describe('PurchasesController usage tests', () => {
   test('sendStripePurchase',
     () => {
       // given
-      const responseData: UserPurchase = {
+      const responseData: UserStripePurchase = {
         currency: 'USD',
         price: '10',
         purchased: 934590234,
@@ -276,7 +277,7 @@ describe('PurchasesController usage tests', () => {
         productId: 'test product id',
         subscriptionId: 'test subscription id',
       };
-      const promiseReturned = new Promise<UserPurchase>(() => responseData);
+      const promiseReturned = new Promise<UserStripePurchase>(() => responseData);
       purchasesController.sendStripePurchase = jest.fn(async () => promiseReturned);
 
       // when
@@ -291,7 +292,7 @@ describe('PurchasesController usage tests', () => {
   test('sendPaddlePurchase',
     () => {
       // given
-      const responseData: UserPurchase = {
+      const responseData: UserPaddlePurchase = {
         currency: 'USD',
         price: '9.99',
         purchased: 1716300000,
@@ -314,7 +315,7 @@ describe('PurchasesController usage tests', () => {
         subscriptionId: 'sub_01hv4rrk',
         type: 'subscription',
       };
-      const promiseReturned = new Promise<UserPurchase>(() => responseData);
+      const promiseReturned = new Promise<UserPaddlePurchase>(() => responseData);
       purchasesController.sendPaddlePurchase = jest.fn(async () => promiseReturned);
 
       // when

--- a/sdk/src/__tests__/internal/QonversionInternal.test.ts
+++ b/sdk/src/__tests__/internal/QonversionInternal.test.ts
@@ -298,7 +298,6 @@ describe('PurchasesController usage tests', () => {
         purchased: 1716300000,
         paddleStoreData: {
           transactionId: 'txn_01hv4rrk',
-          customerId: 'ctm_01hv4rrk',
           productId: 'pro_01hv4rrk',
           subscriptionId: 'sub_01hv4rrk',
           type: 'subscription',
@@ -310,7 +309,6 @@ describe('PurchasesController usage tests', () => {
         price: '9.99',
         purchased: 1716300000,
         transactionId: 'txn_01hv4rrk',
-        customerId: 'ctm_01hv4rrk',
         productId: 'pro_01hv4rrk',
         subscriptionId: 'sub_01hv4rrk',
         type: 'subscription',

--- a/sdk/src/__tests__/internal/network/RequestConfigurator.test.ts
+++ b/sdk/src/__tests__/internal/network/RequestConfigurator.test.ts
@@ -216,7 +216,7 @@ describe('RequestConfigurator tests', () => {
           transaction_id: data.transactionId,
           customer_id: data.customerId,
           product_id: data.productId,
-          type: data.type,
+          type: 'subscription',
           subscription_id: data.subscriptionId,
         },
         purchased: data.purchased,
@@ -230,7 +230,7 @@ describe('RequestConfigurator tests', () => {
     expect(request).toStrictEqual(expResult);
   });
 
-  test('paddle inapp purchase request omits subscription_id', () => {
+  test("paddle inapp purchase request omits subscription_id and maps 'inapp' to wire 'non_recurring'", () => {
     // given
     const data: PurchaseCoreData & PaddleStoreData = {
       currency: 'USD',
@@ -252,7 +252,8 @@ describe('RequestConfigurator tests', () => {
           transaction_id: data.transactionId,
           customer_id: data.customerId,
           product_id: data.productId,
-          type: data.type,
+          // Wire enum: server expects "non_recurring", not "inapp".
+          type: 'non_recurring',
         },
         purchased: data.purchased,
       },

--- a/sdk/src/__tests__/internal/network/RequestConfigurator.test.ts
+++ b/sdk/src/__tests__/internal/network/RequestConfigurator.test.ts
@@ -200,7 +200,6 @@ describe('RequestConfigurator tests', () => {
       price: '9.99',
       purchased: 1716300000,
       transactionId: 'txn_01hv4rrk',
-      customerId: 'ctm_01hv4rrk',
       productId: 'pro_01hv4rrk',
       subscriptionId: 'sub_01hv4rrk',
       type: 'subscription',
@@ -214,7 +213,6 @@ describe('RequestConfigurator tests', () => {
         currency: data.currency,
         paddle_store_data: {
           transaction_id: data.transactionId,
-          customer_id: data.customerId,
           product_id: data.productId,
           type: 'subscription',
           subscription_id: data.subscriptionId,
@@ -237,7 +235,6 @@ describe('RequestConfigurator tests', () => {
       price: '4.99',
       purchased: 1716300000,
       transactionId: 'txn_01hv4rrk',
-      customerId: 'ctm_01hv4rrk',
       productId: 'pro_01hv4rrk',
       type: 'inapp',
     };
@@ -250,7 +247,6 @@ describe('RequestConfigurator tests', () => {
         currency: data.currency,
         paddle_store_data: {
           transaction_id: data.transactionId,
-          customer_id: data.customerId,
           product_id: data.productId,
           // Wire enum: server expects "non_recurring", not "inapp".
           type: 'non_recurring',

--- a/sdk/src/__tests__/internal/network/RequestConfigurator.test.ts
+++ b/sdk/src/__tests__/internal/network/RequestConfigurator.test.ts
@@ -9,7 +9,7 @@ import {
 import {PrimaryConfig} from '../../../types';
 import {PrimaryConfigProvider} from '../../../internal';
 import {UserDataProvider} from '../../../internal/user';
-import {PurchaseCoreData, StripeStoreData, Environment} from '../../../index';
+import {PaddleStoreData, PurchaseCoreData, StripeStoreData, Environment} from '../../../index';
 
 const testHeaders: RequestHeaders = {a: 'a'};
 const headerBuilder: HeaderBuilder = {
@@ -188,6 +188,78 @@ describe('RequestConfigurator tests', () => {
 
     // when
     const request = requestConfigurator.configureStripePurchaseRequest(testUserId, data);
+
+    // then
+    expect(request).toStrictEqual(expResult);
+  });
+
+  test('paddle subscription purchase request', () => {
+    // given
+    const data: PurchaseCoreData & PaddleStoreData = {
+      currency: 'USD',
+      price: '9.99',
+      purchased: 1716300000,
+      transactionId: 'txn_01hv4rrk',
+      customerId: 'ctm_01hv4rrk',
+      productId: 'pro_01hv4rrk',
+      subscriptionId: 'sub_01hv4rrk',
+      type: 'subscription',
+    };
+    const expResult: NetworkRequest = {
+      headers: testHeaders,
+      type: RequestType.POST,
+      url: `${testBaseUrl}/${ApiEndpoint.Users}/${testUserId}/purchases`,
+      body: {
+        price: data.price,
+        currency: data.currency,
+        paddle_store_data: {
+          transaction_id: data.transactionId,
+          customer_id: data.customerId,
+          product_id: data.productId,
+          type: data.type,
+          subscription_id: data.subscriptionId,
+        },
+        purchased: data.purchased,
+      },
+    };
+
+    // when
+    const request = requestConfigurator.configurePaddlePurchaseRequest(testUserId, data);
+
+    // then
+    expect(request).toStrictEqual(expResult);
+  });
+
+  test('paddle inapp purchase request omits subscription_id', () => {
+    // given
+    const data: PurchaseCoreData & PaddleStoreData = {
+      currency: 'USD',
+      price: '4.99',
+      purchased: 1716300000,
+      transactionId: 'txn_01hv4rrk',
+      customerId: 'ctm_01hv4rrk',
+      productId: 'pro_01hv4rrk',
+      type: 'inapp',
+    };
+    const expResult: NetworkRequest = {
+      headers: testHeaders,
+      type: RequestType.POST,
+      url: `${testBaseUrl}/${ApiEndpoint.Users}/${testUserId}/purchases`,
+      body: {
+        price: data.price,
+        currency: data.currency,
+        paddle_store_data: {
+          transaction_id: data.transactionId,
+          customer_id: data.customerId,
+          product_id: data.productId,
+          type: data.type,
+        },
+        purchased: data.purchased,
+      },
+    };
+
+    // when
+    const request = requestConfigurator.configurePaddlePurchaseRequest(testUserId, data);
 
     // then
     expect(request).toStrictEqual(expResult);

--- a/sdk/src/__tests__/internal/purchases/PurchasesController.test.ts
+++ b/sdk/src/__tests__/internal/purchases/PurchasesController.test.ts
@@ -1,6 +1,6 @@
 import {UserDataStorage} from '../../../internal/user';
 import {Logger} from '../../../internal/logger';
-import {PurchaseCoreData, StripeStoreData, UserPurchase} from '../../../index';
+import {PaddleStoreData, PurchaseCoreData, StripeStoreData, UserPurchase} from '../../../index';
 import {PurchasesController, PurchasesService, PurchasesControllerImpl} from '../../../internal/purchases';
 
 let purchasesService: PurchasesService;
@@ -70,5 +70,60 @@ describe('sendStripePurchase tests', () => {
     expect(purchasesService.sendStripePurchase).toBeCalledWith(testUserId, testStripePurchaseData);
     expect(logger.error).toBeCalledWith('Failed to send the Stripe purchase', unknownError);
     expect(logger.verbose).toBeCalledWith('Sending Stripe purchase', {userId: testUserId, data: testStripePurchaseData});
+  });
+});
+
+describe('sendPaddlePurchase tests', () => {
+  const testPaddleUserPurchase: UserPurchase = {
+    currency: 'USD',
+    price: '9.99',
+    purchased: 1716300000,
+    paddleStoreData: {
+      transactionId: 'txn_01hv4rrk',
+      customerId: 'ctm_01hv4rrk',
+      productId: 'pro_01hv4rrk',
+      subscriptionId: 'sub_01hv4rrk',
+      type: 'subscription',
+    },
+    userId: testUserId,
+  };
+  const testPaddleSubscriptionData: PurchaseCoreData & PaddleStoreData = {
+    currency: 'USD',
+    price: '9.99',
+    purchased: 1716300000,
+    transactionId: 'txn_01hv4rrk',
+    customerId: 'ctm_01hv4rrk',
+    productId: 'pro_01hv4rrk',
+    subscriptionId: 'sub_01hv4rrk',
+    type: 'subscription',
+  };
+
+  test('successfully sent', async () => {
+    // given
+    userDataStorage.requireOriginalUserId = jest.fn(() => testUserId);
+    purchasesService.sendPaddlePurchase = jest.fn(async () => testPaddleUserPurchase);
+
+    // when
+    const res = await purchasesController.sendPaddlePurchase(testPaddleSubscriptionData);
+
+    // then
+    expect(res).toStrictEqual(testPaddleUserPurchase);
+    expect(userDataStorage.requireOriginalUserId).toBeCalled();
+    expect(purchasesService.sendPaddlePurchase).toBeCalledWith(testUserId, testPaddleSubscriptionData);
+    expect(logger.info).toBeCalledWith('Successfully sent the Paddle purchase', testPaddleUserPurchase);
+    expect(logger.verbose).toBeCalledWith('Sending Paddle purchase', {userId: testUserId, data: testPaddleSubscriptionData});
+  });
+
+  test('unknown error while sending purchase', async () => {
+    // given
+    userDataStorage.requireOriginalUserId = jest.fn(() => testUserId);
+    const unknownError = new Error('unknown error');
+    purchasesService.sendPaddlePurchase = jest.fn(async () => {throw unknownError});
+
+    // when and then
+    await expect(purchasesController.sendPaddlePurchase(testPaddleSubscriptionData)).rejects.toThrow(unknownError);
+    expect(purchasesService.sendPaddlePurchase).toBeCalledWith(testUserId, testPaddleSubscriptionData);
+    expect(logger.error).toBeCalledWith('Failed to send the Paddle purchase', unknownError);
+    expect(logger.verbose).toBeCalledWith('Sending Paddle purchase', {userId: testUserId, data: testPaddleSubscriptionData});
   });
 });

--- a/sdk/src/__tests__/internal/purchases/PurchasesController.test.ts
+++ b/sdk/src/__tests__/internal/purchases/PurchasesController.test.ts
@@ -86,7 +86,6 @@ describe('sendPaddlePurchase tests', () => {
     purchased: 1716300000,
     paddleStoreData: {
       transactionId: 'txn_01hv4rrk',
-      customerId: 'ctm_01hv4rrk',
       productId: 'pro_01hv4rrk',
       subscriptionId: 'sub_01hv4rrk',
       type: 'subscription',
@@ -98,7 +97,6 @@ describe('sendPaddlePurchase tests', () => {
     price: '9.99',
     purchased: 1716300000,
     transactionId: 'txn_01hv4rrk',
-    customerId: 'ctm_01hv4rrk',
     productId: 'pro_01hv4rrk',
     subscriptionId: 'sub_01hv4rrk',
     type: 'subscription',

--- a/sdk/src/__tests__/internal/purchases/PurchasesController.test.ts
+++ b/sdk/src/__tests__/internal/purchases/PurchasesController.test.ts
@@ -1,6 +1,12 @@
 import {UserDataStorage} from '../../../internal/user';
 import {Logger} from '../../../internal/logger';
-import {PaddleStoreData, PurchaseCoreData, StripeStoreData, UserPurchase} from '../../../index';
+import {
+  PaddleStoreData,
+  PurchaseCoreData,
+  StripeStoreData,
+  UserPaddlePurchase,
+  UserStripePurchase,
+} from '../../../index';
 import {PurchasesController, PurchasesService, PurchasesControllerImpl} from '../../../internal/purchases';
 
 let purchasesService: PurchasesService;
@@ -9,7 +15,7 @@ let logger: Logger;
 let purchasesController: PurchasesController;
 
 const testUserId = 'test user id';
-const testUserPurchase: UserPurchase = {
+const testUserPurchase: UserStripePurchase = {
   currency: 'USD',
   price: '10',
   purchased: 3243523432,
@@ -74,7 +80,7 @@ describe('sendStripePurchase tests', () => {
 });
 
 describe('sendPaddlePurchase tests', () => {
-  const testPaddleUserPurchase: UserPurchase = {
+  const testPaddleUserPurchase: UserPaddlePurchase = {
     currency: 'USD',
     price: '9.99',
     purchased: 1716300000,

--- a/sdk/src/__tests__/internal/purchases/PurchasesService.test.ts
+++ b/sdk/src/__tests__/internal/purchases/PurchasesService.test.ts
@@ -120,7 +120,6 @@ describe('sendPaddlePurchase tests', function () {
     userId: testUserId,
     paddle_store_data: {
       transaction_id: 'txn_01hv4rrk',
-      customer_id: 'ctm_01hv4rrk',
       product_id: 'pro_01hv4rrk',
       subscription_id: 'sub_01hv4rrk',
       type: 'subscription',
@@ -138,7 +137,6 @@ describe('sendPaddlePurchase tests', function () {
     userId: testUserId,
     paddleStoreData: {
       transactionId: 'txn_01hv4rrk',
-      customerId: 'ctm_01hv4rrk',
       productId: 'pro_01hv4rrk',
       subscriptionId: 'sub_01hv4rrk',
       type: 'subscription',
@@ -149,7 +147,6 @@ describe('sendPaddlePurchase tests', function () {
     price: '9.99',
     purchased: 1716300000,
     transactionId: 'txn_01hv4rrk',
-    customerId: 'ctm_01hv4rrk',
     productId: 'pro_01hv4rrk',
     subscriptionId: 'sub_01hv4rrk',
     type: 'subscription',
@@ -179,7 +176,6 @@ describe('sendPaddlePurchase tests', function () {
       userId: testUserId,
       paddle_store_data: {
         transaction_id: 'txn_01hv4rrk',
-        customer_id: 'ctm_01hv4rrk',
         product_id: 'pro_01hv4rrk',
         type: 'non_recurring',
       },
@@ -194,7 +190,6 @@ describe('sendPaddlePurchase tests', function () {
       price: '4.99',
       purchased: 1716300000,
       transactionId: 'txn_01hv4rrk',
-      customerId: 'ctm_01hv4rrk',
       productId: 'pro_01hv4rrk',
       type: 'inapp',
     };

--- a/sdk/src/__tests__/internal/purchases/PurchasesService.test.ts
+++ b/sdk/src/__tests__/internal/purchases/PurchasesService.test.ts
@@ -11,7 +11,8 @@ import {
   QonversionError,
   QonversionErrorCode,
   StripeStoreData,
-  UserPurchase
+  UserPaddlePurchase,
+  UserStripePurchase,
 } from '../../../index';
 import {PurchaseServiceImpl, PurchasesService, UserPurchaseApi} from '../../../internal/purchases';
 
@@ -45,7 +46,7 @@ const testErrorResponse: ApiResponseError = {
   type: '',
   isSuccess: false,
 };
-const expRes: UserPurchase = {
+const expRes: UserStripePurchase = {
   currency: 'USD',
   price: '10',
   purchased: 3243523432,
@@ -112,7 +113,7 @@ describe('sendPaddlePurchase tests', function () {
   // @ts-ignore
   const testRequest: NetworkRequest = {a: 'bb'};
 
-  const apiPaddlePurchase: UserPurchaseApi = {
+  const apiPaddleSubsPurchase: UserPurchaseApi = {
     currency: 'USD',
     price: '9.99',
     purchased: 1716300000,
@@ -127,10 +128,10 @@ describe('sendPaddlePurchase tests', function () {
   };
   const testPaddleSuccessResponse: ApiResponseSuccess<UserPurchaseApi> = {
     code: 200,
-    data: apiPaddlePurchase,
+    data: apiPaddleSubsPurchase,
     isSuccess: true,
   };
-  const expPaddleRes: UserPurchase = {
+  const expPaddleRes: UserPaddlePurchase = {
     currency: 'USD',
     price: '9.99',
     purchased: 1716300000,
@@ -154,7 +155,7 @@ describe('sendPaddlePurchase tests', function () {
     type: 'subscription',
   };
 
-  test('purchase successfully sent', async () => {
+  test('subscription purchase successfully sent', async () => {
     // given
     requestConfigurator.configurePaddlePurchaseRequest = jest.fn(() => testRequest);
     // @ts-ignore
@@ -167,6 +168,45 @@ describe('sendPaddlePurchase tests', function () {
     expect(res).toStrictEqual(expPaddleRes);
     expect(requestConfigurator.configurePaddlePurchaseRequest).toBeCalledWith(testUserId, testPaddlePurchaseRequest);
     expect(apiInteractor.execute).toBeCalledWith(testRequest);
+  });
+
+  test("inapp response is normalized from wire 'non_recurring' to 'inapp'", async () => {
+    // given — gateway returns the wire enum value "non_recurring".
+    const apiInappPurchase: UserPurchaseApi = {
+      currency: 'USD',
+      price: '4.99',
+      purchased: 1716300000,
+      userId: testUserId,
+      paddle_store_data: {
+        transaction_id: 'txn_01hv4rrk',
+        customer_id: 'ctm_01hv4rrk',
+        product_id: 'pro_01hv4rrk',
+        type: 'non_recurring',
+      },
+    };
+    const inappResponse: ApiResponseSuccess<UserPurchaseApi> = {
+      code: 200,
+      data: apiInappPurchase,
+      isSuccess: true,
+    };
+    const inappRequest: PurchaseCoreData & PaddleStoreData = {
+      currency: 'USD',
+      price: '4.99',
+      purchased: 1716300000,
+      transactionId: 'txn_01hv4rrk',
+      customerId: 'ctm_01hv4rrk',
+      productId: 'pro_01hv4rrk',
+      type: 'inapp',
+    };
+    requestConfigurator.configurePaddlePurchaseRequest = jest.fn(() => testRequest);
+    // @ts-ignore
+    apiInteractor.execute = jest.fn(async () => inappResponse);
+
+    // when
+    const res = await purchasesService.sendPaddlePurchase(testUserId, inappRequest);
+
+    // then — SDK surfaces the Paddle-native "inapp", not the wire "non_recurring".
+    expect(res.paddleStoreData.type).toStrictEqual('inapp');
   });
 
   test('send purchase request failed', async () => {

--- a/sdk/src/__tests__/internal/purchases/PurchasesService.test.ts
+++ b/sdk/src/__tests__/internal/purchases/PurchasesService.test.ts
@@ -6,6 +6,7 @@ import {
   ApiResponseSuccess
 } from '../../../internal/network';
 import {
+  PaddleStoreData,
   PurchaseCoreData,
   QonversionError,
   QonversionErrorCode,
@@ -103,6 +104,83 @@ describe('sendStripePurchase tests', function () {
     // when and then
     await expect(() => purchasesService.sendStripePurchase(testUserId, testStripePurchaseRequest)).rejects.toThrow(expError);
     expect(requestConfigurator.configureStripePurchaseRequest).toBeCalledWith(testUserId, testStripePurchaseRequest);
+    expect(apiInteractor.execute).toBeCalledWith(testRequest);
+  });
+});
+
+describe('sendPaddlePurchase tests', function () {
+  // @ts-ignore
+  const testRequest: NetworkRequest = {a: 'bb'};
+
+  const apiPaddlePurchase: UserPurchaseApi = {
+    currency: 'USD',
+    price: '9.99',
+    purchased: 1716300000,
+    userId: testUserId,
+    paddle_store_data: {
+      transaction_id: 'txn_01hv4rrk',
+      customer_id: 'ctm_01hv4rrk',
+      product_id: 'pro_01hv4rrk',
+      subscription_id: 'sub_01hv4rrk',
+      type: 'subscription',
+    },
+  };
+  const testPaddleSuccessResponse: ApiResponseSuccess<UserPurchaseApi> = {
+    code: 200,
+    data: apiPaddlePurchase,
+    isSuccess: true,
+  };
+  const expPaddleRes: UserPurchase = {
+    currency: 'USD',
+    price: '9.99',
+    purchased: 1716300000,
+    userId: testUserId,
+    paddleStoreData: {
+      transactionId: 'txn_01hv4rrk',
+      customerId: 'ctm_01hv4rrk',
+      productId: 'pro_01hv4rrk',
+      subscriptionId: 'sub_01hv4rrk',
+      type: 'subscription',
+    },
+  };
+  const testPaddlePurchaseRequest: PurchaseCoreData & PaddleStoreData = {
+    currency: 'USD',
+    price: '9.99',
+    purchased: 1716300000,
+    transactionId: 'txn_01hv4rrk',
+    customerId: 'ctm_01hv4rrk',
+    productId: 'pro_01hv4rrk',
+    subscriptionId: 'sub_01hv4rrk',
+    type: 'subscription',
+  };
+
+  test('purchase successfully sent', async () => {
+    // given
+    requestConfigurator.configurePaddlePurchaseRequest = jest.fn(() => testRequest);
+    // @ts-ignore
+    apiInteractor.execute = jest.fn(async () => testPaddleSuccessResponse);
+
+    // when
+    const res = await purchasesService.sendPaddlePurchase(testUserId, testPaddlePurchaseRequest);
+
+    // then
+    expect(res).toStrictEqual(expPaddleRes);
+    expect(requestConfigurator.configurePaddlePurchaseRequest).toBeCalledWith(testUserId, testPaddlePurchaseRequest);
+    expect(apiInteractor.execute).toBeCalledWith(testRequest);
+  });
+
+  test('send purchase request failed', async () => {
+    // given
+    requestConfigurator.configurePaddlePurchaseRequest = jest.fn(() => testRequest);
+    apiInteractor.execute = jest.fn(async () => testErrorResponse);
+    const expError = new QonversionError(
+      QonversionErrorCode.BackendError,
+      `Response code ${testErrorCode}, message: ${testErrorMessage}`,
+    );
+
+    // when and then
+    await expect(() => purchasesService.sendPaddlePurchase(testUserId, testPaddlePurchaseRequest)).rejects.toThrow(expError);
+    expect(requestConfigurator.configurePaddlePurchaseRequest).toBeCalledWith(testUserId, testPaddlePurchaseRequest);
     expect(apiInteractor.execute).toBeCalledWith(testRequest);
   });
 });

--- a/sdk/src/dto/Purchase.ts
+++ b/sdk/src/dto/Purchase.ts
@@ -20,9 +20,20 @@ export type PaddleStoreData = {
   subscriptionId?: string;
 };
 
-export type UserPurchase = PurchaseCoreData & {
+export type UserStripePurchase = PurchaseCoreData & {
   purchased: number;
   userId: string;
-  stripeStoreData?: StripeStoreData;
-  paddleStoreData?: PaddleStoreData;
+  stripeStoreData: StripeStoreData;
 };
+
+export type UserPaddlePurchase = PurchaseCoreData & {
+  purchased: number;
+  userId: string;
+  paddleStoreData: PaddleStoreData;
+};
+
+// Discriminated union — a UserPurchase carries exactly one store's data.
+// Functions that produce a purchase (sendStripePurchase / sendPaddlePurchase)
+// return the narrow type, so consumers that use the return value directly
+// keep the same non-nullable store-data field they had before Paddle support.
+export type UserPurchase = UserStripePurchase | UserPaddlePurchase;

--- a/sdk/src/dto/Purchase.ts
+++ b/sdk/src/dto/Purchase.ts
@@ -9,8 +9,20 @@ export type StripeStoreData = {
   productId: string;
 };
 
+export type PaddlePurchaseType = 'subscription' | 'inapp';
+
+export type PaddleStoreData = {
+  transactionId: string;
+  customerId: string;
+  productId: string;
+  type: PaddlePurchaseType;
+  // Required when type is "subscription"; omitted for "inapp" purchases.
+  subscriptionId?: string;
+};
+
 export type UserPurchase = PurchaseCoreData & {
   purchased: number;
-  stripeStoreData: StripeStoreData;
   userId: string;
+  stripeStoreData?: StripeStoreData;
+  paddleStoreData?: PaddleStoreData;
 };

--- a/sdk/src/dto/Purchase.ts
+++ b/sdk/src/dto/Purchase.ts
@@ -13,7 +13,6 @@ export type PaddlePurchaseType = 'subscription' | 'inapp';
 
 export type PaddleStoreData = {
   transactionId: string;
-  customerId: string;
   productId: string;
   type: PaddlePurchaseType;
   // Required when type is "subscription"; omitted for "inapp" purchases.

--- a/sdk/src/internal/QonversionInternal.ts
+++ b/sdk/src/internal/QonversionInternal.ts
@@ -10,7 +10,7 @@ import {UserController} from './user';
 import {EntitlementsController} from './entitlements';
 import {Entitlement} from '../dto/Entitlement';
 import {PurchasesController} from './purchases';
-import {PurchaseCoreData, StripeStoreData, UserPurchase} from '../dto/Purchase';
+import {PaddleStoreData, PurchaseCoreData, StripeStoreData, UserPurchase} from '../dto/Purchase';
 import {Logger} from './logger';
 import {UserProperties} from '../dto/UserProperties';
 
@@ -37,6 +37,11 @@ export class QonversionInternal implements QonversionInstance {
   sendStripePurchase(data: PurchaseCoreData & StripeStoreData): Promise<UserPurchase> {
     this.logger.verbose("sendStripePurchase() call");
     return this.purchasesController.sendStripePurchase(data);
+  }
+
+  sendPaddlePurchase(data: PurchaseCoreData & PaddleStoreData): Promise<UserPurchase> {
+    this.logger.verbose("sendPaddlePurchase() call");
+    return this.purchasesController.sendPaddlePurchase(data);
   }
 
   entitlements(): Promise<Entitlement[]> {

--- a/sdk/src/internal/QonversionInternal.ts
+++ b/sdk/src/internal/QonversionInternal.ts
@@ -10,7 +10,13 @@ import {UserController} from './user';
 import {EntitlementsController} from './entitlements';
 import {Entitlement} from '../dto/Entitlement';
 import {PurchasesController} from './purchases';
-import {PaddleStoreData, PurchaseCoreData, StripeStoreData, UserPurchase} from '../dto/Purchase';
+import {
+  PaddleStoreData,
+  PurchaseCoreData,
+  StripeStoreData,
+  UserPaddlePurchase,
+  UserStripePurchase,
+} from '../dto/Purchase';
 import {Logger} from './logger';
 import {UserProperties} from '../dto/UserProperties';
 
@@ -34,12 +40,12 @@ export class QonversionInternal implements QonversionInstance {
     this.logger.verbose("The QonversionInstance is created");
   }
 
-  sendStripePurchase(data: PurchaseCoreData & StripeStoreData): Promise<UserPurchase> {
+  sendStripePurchase(data: PurchaseCoreData & StripeStoreData): Promise<UserStripePurchase> {
     this.logger.verbose("sendStripePurchase() call");
     return this.purchasesController.sendStripePurchase(data);
   }
 
-  sendPaddlePurchase(data: PurchaseCoreData & PaddleStoreData): Promise<UserPurchase> {
+  sendPaddlePurchase(data: PurchaseCoreData & PaddleStoreData): Promise<UserPaddlePurchase> {
     this.logger.verbose("sendPaddlePurchase() call");
     return this.purchasesController.sendPaddlePurchase(data);
   }

--- a/sdk/src/internal/network/RequestConfigurator.ts
+++ b/sdk/src/internal/network/RequestConfigurator.ts
@@ -94,11 +94,13 @@ export class RequestConfiguratorImpl implements RequestConfigurator {
       transaction_id: data.transactionId,
       customer_id: data.customerId,
       product_id: data.productId,
-      type: data.type,
+      // Wire format uses "non_recurring" for one-time purchases (consistent
+      // with the server-side UserPurchaseProductType enum used by all other
+      // stores). SDK callers express it as the more Paddle-native "inapp".
+      type: data.type === 'inapp' ? 'non_recurring' : 'subscription',
     };
-    // Paddle one-time purchases (`type: 'inapp'`) have no subscription id; omit
-    // the field entirely instead of sending an empty string so the api-gateway
-    // PaddleStoreData parser doesn't reject it.
+    // Paddle one-time purchases have no subscription id; omit the field
+    // entirely instead of sending an empty string.
     if (data.subscriptionId !== undefined) {
       paddleStoreData.subscription_id = data.subscriptionId;
     }

--- a/sdk/src/internal/network/RequestConfigurator.ts
+++ b/sdk/src/internal/network/RequestConfigurator.ts
@@ -92,7 +92,6 @@ export class RequestConfiguratorImpl implements RequestConfigurator {
     const url = `${this.baseUrl}/${ApiEndpoint.Users}/${userId}/purchases`;
     const paddleStoreData: RequestBody = {
       transaction_id: data.transactionId,
-      customer_id: data.customerId,
       product_id: data.productId,
       type: paddleSdkTypeToWire(data.type),
     };

--- a/sdk/src/internal/network/RequestConfigurator.ts
+++ b/sdk/src/internal/network/RequestConfigurator.ts
@@ -94,10 +94,7 @@ export class RequestConfiguratorImpl implements RequestConfigurator {
       transaction_id: data.transactionId,
       customer_id: data.customerId,
       product_id: data.productId,
-      // Wire format uses "non_recurring" for one-time purchases (consistent
-      // with the server-side UserPurchaseProductType enum used by all other
-      // stores). SDK callers express it as the more Paddle-native "inapp".
-      type: data.type === 'inapp' ? 'non_recurring' : 'subscription',
+      type: paddleSdkTypeToWire(data.type),
     };
     // Paddle one-time purchases have no subscription id; omit the field
     // entirely instead of sending an empty string.
@@ -130,6 +127,24 @@ export class RequestConfiguratorImpl implements RequestConfigurator {
       headers,
       type,
       body,
+    }
+  }
+}
+
+// Wire format uses "non_recurring" for one-time purchases (consistent with
+// the server-side UserPurchaseProductType enum shared by every store). The
+// SDK exposes the more Paddle-native "inapp". An explicit switch + exhaustive
+// `never` default means any new PaddlePurchaseType variant fails the type
+// checker here instead of silently aliasing to "subscription" at runtime.
+function paddleSdkTypeToWire(t: PaddleStoreData['type']): 'subscription' | 'non_recurring' {
+  switch (t) {
+    case 'subscription':
+      return 'subscription';
+    case 'inapp':
+      return 'non_recurring';
+    default: {
+      const _exhaustive: never = t;
+      throw new Error(`unhandled PaddlePurchaseType: ${String(_exhaustive)}`);
     }
   }
 }

--- a/sdk/src/internal/network/RequestConfigurator.ts
+++ b/sdk/src/internal/network/RequestConfigurator.ts
@@ -9,7 +9,7 @@ import {
 } from './types';
 import {PrimaryConfigProvider} from '../types';
 import {UserDataProvider} from '../user';
-import {PurchaseCoreData, StripeStoreData} from '../../dto/Purchase';
+import {PaddleStoreData, PurchaseCoreData, StripeStoreData} from '../../dto/Purchase';
 import {Environment} from '../../dto/Environment';
 import {UserPropertyData} from '../userProperties';
 
@@ -82,6 +82,30 @@ export class RequestConfiguratorImpl implements RequestConfigurator {
         subscription_id: data.subscriptionId,
         product_id: data.productId,
       },
+      purchased: data.purchased,
+    };
+
+    return this.configureRequest(url, RequestType.POST, body);
+  }
+
+  configurePaddlePurchaseRequest(userId: string, data: PurchaseCoreData & PaddleStoreData): NetworkRequest {
+    const url = `${this.baseUrl}/${ApiEndpoint.Users}/${userId}/purchases`;
+    const paddleStoreData: RequestBody = {
+      transaction_id: data.transactionId,
+      customer_id: data.customerId,
+      product_id: data.productId,
+      type: data.type,
+    };
+    // Paddle one-time purchases (`type: 'inapp'`) have no subscription id; omit
+    // the field entirely instead of sending an empty string so the api-gateway
+    // PaddleStoreData parser doesn't reject it.
+    if (data.subscriptionId !== undefined) {
+      paddleStoreData.subscription_id = data.subscriptionId;
+    }
+    const body = {
+      price: data.price,
+      currency: data.currency,
+      paddle_store_data: paddleStoreData,
       purchased: data.purchased,
     };
 

--- a/sdk/src/internal/network/types.ts
+++ b/sdk/src/internal/network/types.ts
@@ -1,5 +1,5 @@
 import {RetryPolicy} from './RetryPolicy';
-import {PurchaseCoreData, StripeStoreData} from '../../dto/Purchase';
+import {PaddleStoreData, PurchaseCoreData, StripeStoreData} from '../../dto/Purchase';
 import {Environment} from '../../dto/Environment';
 import {UserPropertyData} from '../userProperties';
 
@@ -95,6 +95,8 @@ export type RequestConfigurator = {
   configureEntitlementsRequest: (userId: string) => NetworkRequest;
 
   configureStripePurchaseRequest: (userId: string, data: PurchaseCoreData & StripeStoreData) => NetworkRequest;
+
+  configurePaddlePurchaseRequest: (userId: string, data: PurchaseCoreData & PaddleStoreData) => NetworkRequest;
 };
 
 export type HeaderBuilder = {

--- a/sdk/src/internal/purchases/PurchaseService.ts
+++ b/sdk/src/internal/purchases/PurchaseService.ts
@@ -1,5 +1,5 @@
 import {PurchasesService, UserPurchaseApi} from './types';
-import {PurchaseCoreData, StripeStoreData, UserPurchase} from '../../dto/Purchase';
+import {PaddleStoreData, PurchaseCoreData, StripeStoreData, UserPurchase} from '../../dto/Purchase';
 import {ApiInteractor, RequestConfigurator} from '../network';
 import {camelCaseKeys} from '../utils/objectUtils';
 import {QonversionError} from '../../exception/QonversionError';
@@ -16,6 +16,15 @@ export class PurchaseServiceImpl implements PurchasesService {
 
   async sendStripePurchase(userId: string, data: PurchaseCoreData & StripeStoreData): Promise<UserPurchase> {
     const request = this.requestConfigurator.configureStripePurchaseRequest(userId, data);
+    return this.executePurchaseRequest(request);
+  }
+
+  async sendPaddlePurchase(userId: string, data: PurchaseCoreData & PaddleStoreData): Promise<UserPurchase> {
+    const request = this.requestConfigurator.configurePaddlePurchaseRequest(userId, data);
+    return this.executePurchaseRequest(request);
+  }
+
+  private async executePurchaseRequest(request: ReturnType<RequestConfigurator['configureStripePurchaseRequest']>): Promise<UserPurchase> {
     const response = await this.apiInteractor.execute<UserPurchaseApi>(request);
 
     if (response.isSuccess) {

--- a/sdk/src/internal/purchases/PurchaseService.ts
+++ b/sdk/src/internal/purchases/PurchaseService.ts
@@ -1,5 +1,6 @@
-import {PurchasesService, UserPurchaseApi} from './types';
+import {PaddleStoreDataApi, PurchasesService, UserPurchaseApi} from './types';
 import {
+  PaddlePurchaseType,
   PaddleStoreData,
   PurchaseCoreData,
   StripeStoreData,
@@ -28,11 +29,14 @@ export class PurchaseServiceImpl implements PurchasesService {
   async sendPaddlePurchase(userId: string, data: PurchaseCoreData & PaddleStoreData): Promise<UserPaddlePurchase> {
     const request = this.requestConfigurator.configurePaddlePurchaseRequest(userId, data);
     const purchase = await this.executePurchaseRequest<UserPaddlePurchase>(request);
-    // Wire format uses "non_recurring" for one-time purchases (matches the
-    // shared UserPurchaseProductType enum on the server); the SDK exposes it
-    // as the Paddle-native "inapp". Normalize on the read path.
-    if (purchase.paddleStoreData && (purchase.paddleStoreData.type as string) === 'non_recurring') {
-      purchase.paddleStoreData.type = 'inapp';
+    if (purchase.paddleStoreData) {
+      // The response from the api comes back with the wire-shape type literal
+      // ("non_recurring" / "subscription"); normalize to the SDK shape
+      // ("inapp" / "subscription") at the boundary so callers never see the
+      // wire literal.
+      purchase.paddleStoreData.type = paddleWireTypeToSdk(
+        (purchase.paddleStoreData as unknown as PaddleStoreDataApi).type,
+      );
     }
     return purchase;
   }
@@ -46,5 +50,21 @@ export class PurchaseServiceImpl implements PurchasesService {
 
     const errorMessage = `Response code ${response.code}, message: ${response.message}`;
     throw new QonversionError(QonversionErrorCode.BackendError, errorMessage);
+  }
+}
+
+// Inverse of paddleSdkTypeToWire in RequestConfigurator. Exhaustive switch +
+// `never` default makes adding a new wire variant a type-check failure
+// instead of an undefined runtime cast.
+function paddleWireTypeToSdk(wire: PaddleStoreDataApi['type']): PaddlePurchaseType {
+  switch (wire) {
+    case 'subscription':
+      return 'subscription';
+    case 'non_recurring':
+      return 'inapp';
+    default: {
+      const _exhaustive: never = wire;
+      throw new Error(`unhandled wire paddle type: ${String(_exhaustive)}`);
+    }
   }
 }

--- a/sdk/src/internal/purchases/PurchaseService.ts
+++ b/sdk/src/internal/purchases/PurchaseService.ts
@@ -1,6 +1,12 @@
 import {PurchasesService, UserPurchaseApi} from './types';
-import {PaddleStoreData, PurchaseCoreData, StripeStoreData, UserPurchase} from '../../dto/Purchase';
-import {ApiInteractor, RequestConfigurator} from '../network';
+import {
+  PaddleStoreData,
+  PurchaseCoreData,
+  StripeStoreData,
+  UserPaddlePurchase,
+  UserStripePurchase,
+} from '../../dto/Purchase';
+import {ApiInteractor, NetworkRequest, RequestConfigurator} from '../network';
 import {camelCaseKeys} from '../utils/objectUtils';
 import {QonversionError} from '../../exception/QonversionError';
 import {QonversionErrorCode} from '../../exception/QonversionErrorCode';
@@ -14,17 +20,24 @@ export class PurchaseServiceImpl implements PurchasesService {
     this.apiInteractor = apiInteractor;
   }
 
-  async sendStripePurchase(userId: string, data: PurchaseCoreData & StripeStoreData): Promise<UserPurchase> {
+  async sendStripePurchase(userId: string, data: PurchaseCoreData & StripeStoreData): Promise<UserStripePurchase> {
     const request = this.requestConfigurator.configureStripePurchaseRequest(userId, data);
-    return this.executePurchaseRequest(request);
+    return this.executePurchaseRequest<UserStripePurchase>(request);
   }
 
-  async sendPaddlePurchase(userId: string, data: PurchaseCoreData & PaddleStoreData): Promise<UserPurchase> {
+  async sendPaddlePurchase(userId: string, data: PurchaseCoreData & PaddleStoreData): Promise<UserPaddlePurchase> {
     const request = this.requestConfigurator.configurePaddlePurchaseRequest(userId, data);
-    return this.executePurchaseRequest(request);
+    const purchase = await this.executePurchaseRequest<UserPaddlePurchase>(request);
+    // Wire format uses "non_recurring" for one-time purchases (matches the
+    // shared UserPurchaseProductType enum on the server); the SDK exposes it
+    // as the Paddle-native "inapp". Normalize on the read path.
+    if (purchase.paddleStoreData && (purchase.paddleStoreData.type as string) === 'non_recurring') {
+      purchase.paddleStoreData.type = 'inapp';
+    }
+    return purchase;
   }
 
-  private async executePurchaseRequest(request: ReturnType<RequestConfigurator['configureStripePurchaseRequest']>): Promise<UserPurchase> {
+  private async executePurchaseRequest<T>(request: NetworkRequest): Promise<T> {
     const response = await this.apiInteractor.execute<UserPurchaseApi>(request);
 
     if (response.isSuccess) {

--- a/sdk/src/internal/purchases/PurchasesController.ts
+++ b/sdk/src/internal/purchases/PurchasesController.ts
@@ -1,7 +1,13 @@
 import {PurchasesController, PurchasesService} from './types';
 import {UserDataStorage} from '../user';
 import {Logger} from '../logger';
-import {PaddleStoreData, PurchaseCoreData, StripeStoreData, UserPurchase} from '../../dto/Purchase';
+import {
+  PaddleStoreData,
+  PurchaseCoreData,
+  StripeStoreData,
+  UserPaddlePurchase,
+  UserStripePurchase,
+} from '../../dto/Purchase';
 
 export class PurchasesControllerImpl implements PurchasesController {
   private readonly purchasesService: PurchasesService;
@@ -14,7 +20,7 @@ export class PurchasesControllerImpl implements PurchasesController {
     this.logger = logger;
   }
 
-  async sendStripePurchase(data: PurchaseCoreData & StripeStoreData): Promise<UserPurchase> {
+  async sendStripePurchase(data: PurchaseCoreData & StripeStoreData): Promise<UserStripePurchase> {
     try {
       const userId = this.userDataStorage.requireOriginalUserId();
       this.logger.verbose('Sending Stripe purchase', {userId, data});
@@ -27,7 +33,7 @@ export class PurchasesControllerImpl implements PurchasesController {
     }
   }
 
-  async sendPaddlePurchase(data: PurchaseCoreData & PaddleStoreData): Promise<UserPurchase> {
+  async sendPaddlePurchase(data: PurchaseCoreData & PaddleStoreData): Promise<UserPaddlePurchase> {
     try {
       const userId = this.userDataStorage.requireOriginalUserId();
       this.logger.verbose('Sending Paddle purchase', {userId, data});

--- a/sdk/src/internal/purchases/PurchasesController.ts
+++ b/sdk/src/internal/purchases/PurchasesController.ts
@@ -1,7 +1,7 @@
 import {PurchasesController, PurchasesService} from './types';
 import {UserDataStorage} from '../user';
 import {Logger} from '../logger';
-import {PurchaseCoreData, StripeStoreData, UserPurchase} from '../../dto/Purchase';
+import {PaddleStoreData, PurchaseCoreData, StripeStoreData, UserPurchase} from '../../dto/Purchase';
 
 export class PurchasesControllerImpl implements PurchasesController {
   private readonly purchasesService: PurchasesService;
@@ -23,6 +23,19 @@ export class PurchasesControllerImpl implements PurchasesController {
       return userPurchase;
     } catch (error) {
       this.logger.error('Failed to send the Stripe purchase', error);
+      throw error;
+    }
+  }
+
+  async sendPaddlePurchase(data: PurchaseCoreData & PaddleStoreData): Promise<UserPurchase> {
+    try {
+      const userId = this.userDataStorage.requireOriginalUserId();
+      this.logger.verbose('Sending Paddle purchase', {userId, data});
+      const userPurchase = await this.purchasesService.sendPaddlePurchase(userId, data);
+      this.logger.info('Successfully sent the Paddle purchase', userPurchase);
+      return userPurchase;
+    } catch (error) {
+      this.logger.error('Failed to send the Paddle purchase', error);
       throw error;
     }
   }

--- a/sdk/src/internal/purchases/types.ts
+++ b/sdk/src/internal/purchases/types.ts
@@ -1,11 +1,13 @@
-import {PurchaseCoreData, StripeStoreData, UserPurchase} from '../../dto/Purchase';
+import {PaddleStoreData, PurchaseCoreData, StripeStoreData, UserPurchase} from '../../dto/Purchase';
 
 export type PurchasesService = {
   sendStripePurchase: (userId: string, data: PurchaseCoreData & StripeStoreData) => Promise<UserPurchase>;
+  sendPaddlePurchase: (userId: string, data: PurchaseCoreData & PaddleStoreData) => Promise<UserPurchase>;
 };
 
 export type PurchasesController = {
   sendStripePurchase: (data: PurchaseCoreData & StripeStoreData) => Promise<UserPurchase>;
+  sendPaddlePurchase: (data: PurchaseCoreData & PaddleStoreData) => Promise<UserPurchase>;
 };
 
 export type PurchaseCoreDataApi = {
@@ -20,6 +22,15 @@ export type StripeStoreDataApi = {
   product_id: string;
 };
 
+export type PaddleStoreDataApi = {
+  transaction_id: string;
+  customer_id: string;
+  product_id: string;
+  type: 'subscription' | 'inapp';
+  subscription_id?: string;
+};
+
 export type UserPurchaseApi = PurchaseCoreDataApi & {
-  stripe_store_data: StripeStoreDataApi;
+  stripe_store_data?: StripeStoreDataApi;
+  paddle_store_data?: PaddleStoreDataApi;
 };

--- a/sdk/src/internal/purchases/types.ts
+++ b/sdk/src/internal/purchases/types.ts
@@ -30,7 +30,6 @@ export type StripeStoreDataApi = {
 
 export type PaddleStoreDataApi = {
   transaction_id: string;
-  customer_id: string;
   product_id: string;
   // Wire enum: the server's shared UserPurchaseProductType uses "non_recurring"
   // for one-time purchases. The SDK surfaces it as "inapp"; conversion is

--- a/sdk/src/internal/purchases/types.ts
+++ b/sdk/src/internal/purchases/types.ts
@@ -1,13 +1,19 @@
-import {PaddleStoreData, PurchaseCoreData, StripeStoreData, UserPurchase} from '../../dto/Purchase';
+import {
+  PaddleStoreData,
+  PurchaseCoreData,
+  StripeStoreData,
+  UserPaddlePurchase,
+  UserStripePurchase,
+} from '../../dto/Purchase';
 
 export type PurchasesService = {
-  sendStripePurchase: (userId: string, data: PurchaseCoreData & StripeStoreData) => Promise<UserPurchase>;
-  sendPaddlePurchase: (userId: string, data: PurchaseCoreData & PaddleStoreData) => Promise<UserPurchase>;
+  sendStripePurchase: (userId: string, data: PurchaseCoreData & StripeStoreData) => Promise<UserStripePurchase>;
+  sendPaddlePurchase: (userId: string, data: PurchaseCoreData & PaddleStoreData) => Promise<UserPaddlePurchase>;
 };
 
 export type PurchasesController = {
-  sendStripePurchase: (data: PurchaseCoreData & StripeStoreData) => Promise<UserPurchase>;
-  sendPaddlePurchase: (data: PurchaseCoreData & PaddleStoreData) => Promise<UserPurchase>;
+  sendStripePurchase: (data: PurchaseCoreData & StripeStoreData) => Promise<UserStripePurchase>;
+  sendPaddlePurchase: (data: PurchaseCoreData & PaddleStoreData) => Promise<UserPaddlePurchase>;
 };
 
 export type PurchaseCoreDataApi = {
@@ -26,7 +32,10 @@ export type PaddleStoreDataApi = {
   transaction_id: string;
   customer_id: string;
   product_id: string;
-  type: 'subscription' | 'inapp';
+  // Wire enum: the server's shared UserPurchaseProductType uses "non_recurring"
+  // for one-time purchases. The SDK surfaces it as "inapp"; conversion is
+  // handled in RequestConfigurator (write) and PurchaseService (read).
+  type: 'subscription' | 'non_recurring';
   subscription_id?: string;
 };
 

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -2,31 +2,37 @@ import {LogLevel} from './dto/LogLevel';
 import {Environment} from './dto/Environment';
 import {UserPropertyKey} from './dto/UserPropertyKey';
 import {Entitlement} from './dto/Entitlement';
-import {PaddleStoreData, PurchaseCoreData, StripeStoreData, UserPurchase} from './dto/Purchase';
+import {
+  PaddleStoreData,
+  PurchaseCoreData,
+  StripeStoreData,
+  UserPaddlePurchase,
+  UserStripePurchase,
+} from './dto/Purchase';
 import {UserProperties} from './dto/UserProperties';
 
 export type QonversionInstance = {
   /**
    * Call this function to send completed Stripe purchase to our API. The purchase will be linked to the current user,
-   * and he will gain corresponding entitlements, described in the Qonversion Product Center.
+   * and the user will gain corresponding entitlements, described in the Qonversion Product Center.
    *
    * @param data information about completed purchase.
    * @returns a purchase info, saved on the API.
    */
-  sendStripePurchase: (data: PurchaseCoreData & StripeStoreData) => Promise<UserPurchase>;
+  sendStripePurchase: (data: PurchaseCoreData & StripeStoreData) => Promise<UserStripePurchase>;
 
   /**
-   * Call this function to send completed Paddle purchase to our API. The purchase will be linked to the current user,
-   * and he will gain corresponding entitlements, described in the Qonversion Product Center.
+   * Call this function to send a completed Paddle purchase to our API. The purchase will be linked to the
+   * current user, and the user will gain corresponding entitlements, described in the Qonversion Product Center.
    *
-   * Call this from the Paddle.js `successCallback` after `Paddle.Checkout.open(...)` resolves
-   * with a transaction id. The backend will fetch the transaction (or subscription) from Paddle
-   * synchronously, persist it, and grant entitlements before the promise resolves.
+   * Call this once the checkout completes with a transaction id (e.g. from
+   * `Paddle.Checkout.open(...)`'s success callback). The backend will fetch the transaction (or
+   * subscription) from Paddle synchronously, persist it, and grant entitlements before the promise resolves.
    *
    * @param data information about completed purchase.
    * @returns a purchase info, saved on the API.
    */
-  sendPaddlePurchase: (data: PurchaseCoreData & PaddleStoreData) => Promise<UserPurchase>;
+  sendPaddlePurchase: (data: PurchaseCoreData & PaddleStoreData) => Promise<UserPaddlePurchase>;
 
   /**
    * Call this function to receive all entitlements of the current user. If you initiated user changing

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -2,7 +2,7 @@ import {LogLevel} from './dto/LogLevel';
 import {Environment} from './dto/Environment';
 import {UserPropertyKey} from './dto/UserPropertyKey';
 import {Entitlement} from './dto/Entitlement';
-import {PurchaseCoreData, StripeStoreData, UserPurchase} from './dto/Purchase';
+import {PaddleStoreData, PurchaseCoreData, StripeStoreData, UserPurchase} from './dto/Purchase';
 import {UserProperties} from './dto/UserProperties';
 
 export type QonversionInstance = {
@@ -14,6 +14,19 @@ export type QonversionInstance = {
    * @returns a purchase info, saved on the API.
    */
   sendStripePurchase: (data: PurchaseCoreData & StripeStoreData) => Promise<UserPurchase>;
+
+  /**
+   * Call this function to send completed Paddle purchase to our API. The purchase will be linked to the current user,
+   * and he will gain corresponding entitlements, described in the Qonversion Product Center.
+   *
+   * Call this from the Paddle.js `successCallback` after `Paddle.Checkout.open(...)` resolves
+   * with a transaction id. The backend will fetch the transaction (or subscription) from Paddle
+   * synchronously, persist it, and grant entitlements before the promise resolves.
+   *
+   * @param data information about completed purchase.
+   * @returns a purchase info, saved on the API.
+   */
+  sendPaddlePurchase: (data: PurchaseCoreData & PaddleStoreData) => Promise<UserPurchase>;
 
   /**
    * Call this function to receive all entitlements of the current user. If you initiated user changing


### PR DESCRIPTION
## Summary

Adds `sendPaddlePurchase` as the Paddle counterpart to `sendStripePurchase`. After a checkout completes in Paddle.js, call this method with the `transaction_id` (and `subscription_id` for subscriptions) and the backend validates the purchase and grants entitlements before the promise resolves.

```ts
await Qonversion.shared.sendPaddlePurchase({
  price,
  currency,
  purchased,
  transactionId,
  customerId,
  productId,
  type,         // 'subscription' | 'inapp'
  subscriptionId, // required when type === 'subscription'; omit for 'inapp'
});
```

## Wire flow

- `QonversionInstance.sendPaddlePurchase`
- → `QonversionInternal.sendPaddlePurchase`
- → `PurchasesController.sendPaddlePurchase` (logger + user id lookup, mirrors the stripe path)
- → `PurchasesService.sendPaddlePurchase`
- → `RequestConfigurator.configurePaddlePurchaseRequest` — `POST /v3/users/{userId}/purchases` with body:
  ```json
  {
    "price": "...",
    "currency": "...",
    "purchased": ...,
    "paddle_store_data": {
      "transaction_id": "txn_...",
      "customer_id": "ctm_...",
      "product_id": "pro_...",
      "type": "subscription",
      "subscription_id": "sub_..."
    }
  }
  ```
  For one-time (`type: 'inapp'`) purchases `subscription_id` is omitted from the body entirely.

## Notes

- `UserPurchase.stripeStoreData` and `UserPurchase.paddleStoreData` are now both optional — a purchase row carries exactly one.
- `PurchaseService` grew a small private `executePurchaseRequest` helper to dedupe the success-or-throw shape between Stripe and Paddle.

## Test plan

- [x] `yarn test` → 220/220 (Jest)
- [x] `yarn tsc --noEmit` clean
- [x] New unit tests:
  - `PurchasesService.test.ts`: paddle success + paddle error
  - `PurchasesController.test.ts`: paddle success + paddle error
  - `QonversionInternal.test.ts`: `sendPaddlePurchase` delegation + log line
  - `RequestConfigurator.test.ts`: paddle subscription request body + paddle inapp request body (asserts `subscription_id` is omitted)