### PR TITLE
ci: migrate npm publish workflow to Trusted Publisher (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,30 +1,38 @@
 name: Publish
 
 on:
+  workflow_dispatch:
   release:
     types: [released]
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   publish:
     name: Upload archives
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write    # OIDC for npm trusted publishers
+      contents: read
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm
+        run: npm install -g npm@11.7.0
 
       - name: Build typescript
         run: |
           yarn
           yarn build
 
-      - name: Setup node for publishing
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
-
       - name: Publish to npm
-        run: |
-          npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish


### PR DESCRIPTION
## What

Align the web-sdk publish workflow with the React Native SDK, which already uses npm **Trusted Publishers (OIDC)** instead of a long-lived `NPM_TOKEN` secret.

## Changes to `.github/workflows/publish.yml`

- Add `workflow_dispatch` trigger (manual run).
- Add `permissions: id-token: write` + `contents: read` at workflow and job level (required for OIDC).
- `runs-on`: `macos-latest` -> `ubuntu-latest`.
- Node `20.x` -> `22.x`; upgrade npm to `11.7.0` (Trusted Publishing requires recent npm).
- `npm publish` without `NODE_AUTH_TOKEN` / `secrets.NPM_TOKEN`.
- Keep web-sdk build step (`yarn` + `yarn build`), moved after node setup.

## External prerequisite (outside the repo)

The npm package `@qonversion/web-sdk` must have a **Trusted Publisher** configured on npmjs.org pointing to repo `qonversion/web-sdk` + workflow `publish.yml`, otherwise `npm publish` will fail with an OIDC error. After migration the old `NPM_TOKEN` secret can be removed.

Linear: DEV-999

🤖 Generated with [Claude Code](https://claude.com/claude-code)
