### PR TITLE
fix: flush pending user properties for the previous user on user change (DEV-1233)

### DIFF
--- a/sdk/src/__tests__/internal/network/RequestConfigurator.test.ts
+++ b/sdk/src/__tests__/internal/network/RequestConfigurator.test.ts
@@ -1,5 +1,6 @@
 import {
   ApiEndpoint,
+  ApiHeader,
   HeaderBuilder,
   NetworkRequest,
   RequestConfiguratorImpl,
@@ -81,7 +82,9 @@ describe('RequestConfigurator tests', () => {
     // given
     const properties = [{key: 'a', value: 'a'}, {key: 'b', value: 'b'}];
     const expResult: NetworkRequest = {
-      headers: testHeaders,
+      // The User-Id header must match the addressed user, not the ambient one —
+      // the send may target the previous user during a user-change flush.
+      headers: {...testHeaders, [ApiHeader.UserID]: testUserId},
       type: RequestType.POST,
       url: testBaseUrl + '/' + ApiEndpoint.Users + '/' + testUserId + '/' + ApiEndpoint.Properties,
       body: properties,

--- a/sdk/src/__tests__/internal/userProperties/UserPropertiesController.test.ts
+++ b/sdk/src/__tests__/internal/userProperties/UserPropertiesController.test.ts
@@ -233,6 +233,31 @@ describe('sendUserProperties tests', () => {
     expect(logger.error).not.toBeCalled();
   });
 
+  test('send completing after a user change does not write into the storages', async () => {
+    // given - a send is in flight when the user changes
+    const properties = {a: 'aa'};
+    pendingUserPropertiesStorage.getProperties = jest.fn(() => properties);
+    pendingUserPropertiesStorage.clear = jest.fn();
+    sentUserPropertiesStorage.clear = jest.fn();
+    delayedWorker.cancel = jest.fn();
+
+    let resolveSend: (response: UserPropertiesSendResponse) => void;
+    userPropertiesService.sendProperties = jest.fn(() =>
+      new Promise<UserPropertiesSendResponse>(resolve => {resolveSend = resolve})
+    );
+
+    // when - the user changes mid-flight, then the old send resolves
+    const sendPromise = userPropertiesController['sendUserProperties']();
+    userPropertiesController.onUserChanged('new_user_id');
+    resolveSend!({propertyErrors: [], savedProperties: [{key: 'a', value: 'aa'}]});
+    await sendPromise;
+
+    // then - the stale response is dropped: no storage writes, no re-trigger
+    expect(pendingUserPropertiesStorage.delete).not.toBeCalled();
+    expect(sentUserPropertiesStorage.add).not.toBeCalled();
+    expect(userPropertiesController['sendUserPropertiesIfNeeded']).not.toBeCalled();
+  });
+
   test('send empty properties', async () => {
     // given
     const properties = {};
@@ -369,6 +394,26 @@ describe('onUserChanged tests', () => {
     // then
     expect(userPropertiesService.sendProperties).toBeCalledWith('old_user_id', {test_key: 'test value'});
     expect(logger.error).toBeCalledWith('Failed to send pending user properties for the previous user', expError);
+  });
+
+  test('flush result is not written into the storages', async () => {
+    // given
+    pendingUserPropertiesStorage.getProperties = jest.fn(() => ({test_key: 'test value'}));
+    pendingUserPropertiesStorage.delete = jest.fn();
+    sentUserPropertiesStorage.add = jest.fn();
+    userPropertiesService.sendProperties = jest.fn(async () => ({
+      savedProperties: [{key: 'test_key', value: 'test value'}],
+      propertyErrors: [],
+    }));
+
+    // when
+    userPropertiesController.onUserChanged('new_user_id', 'old_user_id');
+    await new Promise(process.nextTick); // let the fire-and-forget flush resolve
+
+    // then - the flush belongs to the previous user; its response must not
+    // pollute the new user's pending/sent state
+    expect(pendingUserPropertiesStorage.delete).not.toBeCalled();
+    expect(sentUserPropertiesStorage.add).not.toBeCalled();
   });
 
   test('pending properties are not flushed when the old user id is unknown', () => {

--- a/sdk/src/__tests__/internal/userProperties/UserPropertiesController.test.ts
+++ b/sdk/src/__tests__/internal/userProperties/UserPropertiesController.test.ts
@@ -312,17 +312,59 @@ describe('sendUserProperties tests', () => {
 });
 
 describe('onUserChanged tests', () => {
-  test('user changed handling', () => {
-    // given
+  beforeEach(() => {
     pendingUserPropertiesStorage.clear = jest.fn();
     sentUserPropertiesStorage.clear = jest.fn();
+    delayedWorker.cancel = jest.fn();
+  });
+
+  test('user changed handling without pending properties', () => {
+    // given
+    pendingUserPropertiesStorage.getProperties = jest.fn(() => ({}));
+    userPropertiesService.sendProperties = jest.fn();
 
     // when
-    userPropertiesController.onUserChanged();
+    userPropertiesController.onUserChanged('new_user_id', 'old_user_id');
+
+    // then
+    expect(delayedWorker.cancel).toBeCalled();
+    expect(pendingUserPropertiesStorage.clear).toBeCalled();
+    expect(sentUserPropertiesStorage.clear).toBeCalled();
+    expect(userPropertiesService.sendProperties).not.toBeCalled();
+  });
+
+  test('pending properties are flushed for the previous user', () => {
+    // given
+    const pendingProperties = {test_key: 'test value'};
+    const sendResponse: UserPropertiesSendResponse = {
+      savedProperties: [{key: 'test_key', value: 'test value'}],
+      propertyErrors: [],
+    };
+    pendingUserPropertiesStorage.getProperties = jest.fn(() => pendingProperties);
+    userPropertiesService.sendProperties = jest.fn(async () => sendResponse);
+
+    // when
+    userPropertiesController.onUserChanged('new_user_id', 'old_user_id');
+
+    // then
+    expect(delayedWorker.cancel).toBeCalled();
+    expect(pendingUserPropertiesStorage.clear).toBeCalled();
+    expect(sentUserPropertiesStorage.clear).toBeCalled();
+    expect(userPropertiesService.sendProperties).toBeCalledWith('old_user_id', pendingProperties);
+  });
+
+  test('pending properties are not flushed when the old user id is unknown', () => {
+    // given
+    pendingUserPropertiesStorage.getProperties = jest.fn(() => ({test_key: 'test value'}));
+    userPropertiesService.sendProperties = jest.fn();
+
+    // when
+    userPropertiesController.onUserChanged('new_user_id');
 
     // then
     expect(pendingUserPropertiesStorage.clear).toBeCalled();
     expect(sentUserPropertiesStorage.clear).toBeCalled();
+    expect(userPropertiesService.sendProperties).not.toBeCalled();
   });
 });
 

--- a/sdk/src/__tests__/internal/userProperties/UserPropertiesController.test.ts
+++ b/sdk/src/__tests__/internal/userProperties/UserPropertiesController.test.ts
@@ -381,8 +381,9 @@ describe('onUserChanged tests', () => {
   });
 
   test('failed flush for the previous user is logged', async () => {
-    // given
-    const expError = new QonversionError(QonversionErrorCode.BackendError);
+    // given - a plain (non-Qonversion) error pins the UNCONDITIONAL logging:
+    // the storages are already cleared, so the log is the last trace
+    const expError = new Error('network down');
     pendingUserPropertiesStorage.getProperties = jest.fn(() => ({test_key: 'test value'}));
     userPropertiesService.sendProperties = jest.fn(async () => {throw expError});
     logger.error = jest.fn();

--- a/sdk/src/__tests__/internal/userProperties/UserPropertiesController.test.ts
+++ b/sdk/src/__tests__/internal/userProperties/UserPropertiesController.test.ts
@@ -334,13 +334,15 @@ describe('onUserChanged tests', () => {
   });
 
   test('pending properties are flushed for the previous user', () => {
-    // given
-    const pendingProperties = {test_key: 'test value'};
+    // given - stateful storage mock: clear() actually empties it, so this test
+    // pins the snapshot-before-clear ordering, not just the send call
+    let stored: Record<string, string> = {test_key: 'test value'};
     const sendResponse: UserPropertiesSendResponse = {
       savedProperties: [{key: 'test_key', value: 'test value'}],
       propertyErrors: [],
     };
-    pendingUserPropertiesStorage.getProperties = jest.fn(() => pendingProperties);
+    pendingUserPropertiesStorage.getProperties = jest.fn(() => stored);
+    pendingUserPropertiesStorage.clear = jest.fn(() => {stored = {}});
     userPropertiesService.sendProperties = jest.fn(async () => sendResponse);
 
     // when
@@ -350,7 +352,23 @@ describe('onUserChanged tests', () => {
     expect(delayedWorker.cancel).toBeCalled();
     expect(pendingUserPropertiesStorage.clear).toBeCalled();
     expect(sentUserPropertiesStorage.clear).toBeCalled();
-    expect(userPropertiesService.sendProperties).toBeCalledWith('old_user_id', pendingProperties);
+    expect(userPropertiesService.sendProperties).toBeCalledWith('old_user_id', {test_key: 'test value'});
+  });
+
+  test('failed flush for the previous user is logged', async () => {
+    // given
+    const expError = new QonversionError(QonversionErrorCode.BackendError);
+    pendingUserPropertiesStorage.getProperties = jest.fn(() => ({test_key: 'test value'}));
+    userPropertiesService.sendProperties = jest.fn(async () => {throw expError});
+    logger.error = jest.fn();
+
+    // when
+    userPropertiesController.onUserChanged('new_user_id', 'old_user_id');
+    await new Promise(process.nextTick); // flush microtasks for the fire-and-forget catch
+
+    // then
+    expect(userPropertiesService.sendProperties).toBeCalledWith('old_user_id', {test_key: 'test value'});
+    expect(logger.error).toBeCalledWith('Failed to send pending user properties for the previous user', expError);
   });
 
   test('pending properties are not flushed when the old user id is unknown', () => {
@@ -362,6 +380,7 @@ describe('onUserChanged tests', () => {
     userPropertiesController.onUserChanged('new_user_id');
 
     // then
+    expect(delayedWorker.cancel).toBeCalled();
     expect(pendingUserPropertiesStorage.clear).toBeCalled();
     expect(sentUserPropertiesStorage.clear).toBeCalled();
     expect(userPropertiesService.sendProperties).not.toBeCalled();

--- a/sdk/src/internal/network/RequestConfigurator.ts
+++ b/sdk/src/internal/network/RequestConfigurator.ts
@@ -1,5 +1,6 @@
 import {
   ApiEndpoint,
+  ApiHeader,
   HeaderBuilder,
   NetworkRequest,
   RequestBody,
@@ -46,7 +47,10 @@ export class RequestConfiguratorImpl implements RequestConfigurator {
 
   configureUserPropertiesSendRequest(userId: string, properties: UserPropertyData[]): NetworkRequest {
     const url = `${this.baseUrl}/${ApiEndpoint.Users}/${userId}/${ApiEndpoint.Properties}`;
-    return this.configureRequest(url, RequestType.POST, properties);
+    // The common User-Id header reflects the CURRENT user, which may differ
+    // from the addressed one when pending properties are flushed for the
+    // previous user on a user change — keep the header consistent with the URL.
+    return this.configureRequest(url, RequestType.POST, properties, {[ApiHeader.UserID]: userId});
   }
 
   configureUserPropertiesGetRequest(userId: string): NetworkRequest {

--- a/sdk/src/internal/userProperties/UserPropertiesController.ts
+++ b/sdk/src/internal/userProperties/UserPropertiesController.ts
@@ -68,9 +68,28 @@ export class UserPropertiesControllerImpl implements UserPropertiesController, U
     return new UserProperties(mappedProperties);
   }
 
-  onUserChanged(): void {
+  onUserChanged(newUserOriginalId: string, oldUserOriginalId?: string): void {
+    const pendingProperties = {...this.pendingUserPropertiesStorage.getProperties()};
+
+    this.delayedWorker.cancel();
     this.pendingUserPropertiesStorage.clear();
     this.sentUserPropertiesStorage.clear();
+
+    // Properties set right before the user switch belong to the previous user —
+    // flush them on their behalf instead of dropping them silently. The storage
+    // already holds the new user id, so the old id is passed explicitly.
+    if (oldUserOriginalId && Object.keys(pendingProperties).length > 0) {
+      this.logger.verbose(
+        'Flushing pending user properties for the previous user before switching',
+        {oldUserOriginalId, pendingProperties},
+      );
+      this.userPropertiesService.sendProperties(oldUserOriginalId, pendingProperties)
+        .catch(e => {
+          if (e instanceof QonversionError) {
+            this.logger.error('Failed to send pending user properties for the previous user', e);
+          }
+        });
+    }
   }
 
   private sendUserPropertiesIfNeeded(ignoreExistingJob: boolean = false) {

--- a/sdk/src/internal/userProperties/UserPropertiesController.ts
+++ b/sdk/src/internal/userProperties/UserPropertiesController.ts
@@ -17,6 +17,11 @@ export class UserPropertiesControllerImpl implements UserPropertiesController, U
   private readonly logger: Logger;
   private readonly sendingDelayMs: number;
 
+  // Incremented on every user change. A send that was in flight across a user
+  // change must not write its result into the storages — they belong to the
+  // new user by then.
+  private userChangeEpoch: number = 0;
+
   constructor(
     pendingUserPropertiesStorage: UserPropertiesStorage,
     sentUserPropertiesStorage: UserPropertiesStorage,
@@ -71,6 +76,7 @@ export class UserPropertiesControllerImpl implements UserPropertiesController, U
   onUserChanged(newUserOriginalId: string, oldUserOriginalId?: string): void {
     const pendingProperties = {...this.pendingUserPropertiesStorage.getProperties()};
 
+    this.userChangeEpoch++;
     this.delayedWorker.cancel();
     this.pendingUserPropertiesStorage.clear();
     this.sentUserPropertiesStorage.clear();
@@ -85,9 +91,9 @@ export class UserPropertiesControllerImpl implements UserPropertiesController, U
       );
       this.userPropertiesService.sendProperties(oldUserOriginalId, pendingProperties)
         .catch(e => {
-          if (e instanceof QonversionError) {
-            this.logger.error('Failed to send pending user properties for the previous user', e);
-          }
+          // Best effort: the storages are already cleared, so a failed flush is
+          // the last trace of these properties — always leave a log line.
+          this.logger.error('Failed to send pending user properties for the previous user', e);
         });
     }
   }
@@ -114,10 +120,19 @@ export class UserPropertiesControllerImpl implements UserPropertiesController, U
       this.logger.verbose('Sending user properties', propertiesToSend);
 
       const userId = this.userDataStorage.requireOriginalUserId();
+      const epochAtSendStart = this.userChangeEpoch;
       const response = await this.userPropertiesService.sendProperties(
         userId,
         propertiesToSend,
       );
+
+      if (epochAtSendStart !== this.userChangeEpoch) {
+        // The user changed while the request was in flight — the storages now
+        // belong to the new user, and writing this response into them would
+        // poison the new user's pending/sent state.
+        this.logger.verbose('User changed during properties send, skipping the result', {userId});
+        return;
+      }
 
       const processedProperties: Record<string, string> = {};
       response.savedProperties.forEach(savedProperty => {


### PR DESCRIPTION
A7 from the production-defects block of the Remote Config targeting review ([dash-mono PR #674](https://github.com/qonversion/dash-mono/pull/674)). Linear: [DEV-1233](https://linear.app/qonversion/issue/DEV-1233).

## Problem

`onUserChanged` silently dropped the pending-properties buffer, so properties set right before identify/logout never reached the API.

## Fix

The buffer is now flushed on behalf of the previous user before being cleared — the previous user's id is passed explicitly by the notifier, since the storage already holds the new user id by the time the event fires. The scheduled debounce job is cancelled, and both storages are cleared exactly as before. Best-effort: a failed flush is logged and does not affect the new user's state.

## Tests

Unit suite green (223/223). The live-API integration suites fail with 422 "potential fraud" before this change as well — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4V5cx2SMU4VrfPntwfKJ9